### PR TITLE
[Fix Issue #15] Add ability to get historical market prices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 node_modules/
 
+.DS_Store
+.idea
+.log
+
 test.js

--- a/exchange/README.md
+++ b/exchange/README.md
@@ -10,7 +10,7 @@ var exchange = require('blockchain.info/exchange');
 
 ## Methods
 
-All method options can include an `apiCode` property to prevent hitting request limits.
+All methods accept an options *Object* parameter that can include an `apiCode` property to prevent hitting request limits.
 
 ### getTicker
 
@@ -31,23 +31,26 @@ Options (optional):
 Usage:
 
 ```js
-exchange.fromBTC(amount, time, currency, options);
+exchange.fromBTC(amount, currency, options);
 ```
 
 Gets the historical market price of the requested BTC amount at the requested time. Responds with the value in *string* format.
 
-Parameters:
+Required Parameters:
 
   * `amount` - the amount of BTC  (satoshi, *number*)
-  * `time` - the historical date (milliseconds since Unix epoch, *number*)
   * `currency` - the code of the currency to convert from (currency code, *string*)
 
+Options (optional):
+
+  * `time` - the historical date (milliseconds since Unix epoch, *number*)
+  
 ### toBTC
 
 Usage:
 
 ```js
-exchange.toBTC(amount, options);
+exchange.toBTC(amount, currency, options);
 ```
 
 Converts an amount of a given currency to BTC. Responds with a number in *string* format.

--- a/exchange/README.md
+++ b/exchange/README.md
@@ -26,6 +26,22 @@ Options (optional):
 
   * `currency` - specify which currency to get data for (currency code, *string*)
 
+### fromBTC
+
+Usage:
+
+```js
+exchange.fromBTC(amount, time, currency, options);
+```
+
+Gets the historical market price of the requested BTC amount at the requested time. Responds with the value in *string* format.
+
+Parameters:
+
+  * `amount` - the amount of BTC  (satoshi, *number*)
+  * `time` - the historical date (milliseconds since Unix epoch, *number*)
+  * `currency` - the code of the currency to convert from (currency code, *string*)
+
 ### toBTC
 
 Usage:

--- a/exchange/index.js
+++ b/exchange/index.js
@@ -23,10 +23,10 @@ function getTicker(options) {
     .then(function (data) { return data[options.currency] || data; });
 }
 
-function fromBTC(amount, time, currency, options) {
+function fromBTC(amount, currency, options) {
 	options = options || {};
-	return api.request('frombtc', { value: amount, time: time, currency: currency, apiCode: options.apiCode })
-		.then(function (value) { return '' + value; });
+	return api.request('frombtc', { value: amount, time: options.time || 0, currency: currency, apiCode: options.apiCode })
+		.then(function (value) { return parseFloat(value) });
 }
 
 function toBTC(amount, currency, options) {

--- a/exchange/index.js
+++ b/exchange/index.js
@@ -5,6 +5,7 @@ var API         = require('../api')
 
 var endpoints  = {
   ticker  : new UrlPattern('/ticker(?api_code=:apiCode)'),
+	frombtc : new UrlPattern('/frombtc?value=:value&time=:time&currency=:currency(&api_code=:apiCode)'),
   tobtc   : new UrlPattern('/tobtc?value=:value&currency=:currency(&api_code=:apiCode)')
 };
 
@@ -12,6 +13,7 @@ var api = new API('https://blockchain.info', endpoints);
 
 module.exports = {
   getTicker : getTicker,
+	fromBTC   : fromBTC,
   toBTC     : toBTC
 };
 
@@ -19,6 +21,12 @@ function getTicker(options) {
   options = options || {};
   return api.request('ticker', { apiCode: options.apiCode })
     .then(function (data) { return data[options.currency] || data; });
+}
+
+function fromBTC(amount, time, currency, options) {
+	options = options || {};
+	return api.request('frombtc', { value: amount, time: time, currency: currency, apiCode: options.apiCode })
+		.then(function (value) { return '' + value; });
 }
 
 function toBTC(amount, currency, options) {

--- a/exchange/spec.js
+++ b/exchange/spec.js
@@ -47,9 +47,9 @@ describe('exchange', function () {
 			.reply(200, '227.13');
 
 		it('should convert the currency', function (done) {
-			exchange.fromBTC(100000000, 1441308160481, 'USD')
+			exchange.fromBTC(100000000, 'USD')
 				.then(function (response) {
-					expect(response).to.equal('227.13');
+					expect(response).to.equal(227.13);
 					done();
 				})
 				.catch(done);

--- a/exchange/spec.js
+++ b/exchange/spec.js
@@ -7,12 +7,15 @@ var exchange  = require('./index')
 describe('exchange', function () {
 
   describe('.getTicker()', function () {
-    var ticker =  { USD:
-                    { '15m'   : 432.52
-                    , last    : 432.52
-                    , buy     : 432.52
-                    , sell    : 433
-                    , symbol  : '$' }};
+    var ticker =  {
+    	USD: {
+    		'15m'   : 432.52,
+				last    : 432.52,
+				buy     : 432.52,
+				sell    : 433,
+				symbol  : '$'
+    	}
+    };
 
     nock('https://blockchain.info')
       .get('/ticker').times(2)
@@ -35,13 +38,28 @@ describe('exchange', function () {
         })
         .catch(done);
     });
-
   });
 
-  describe('.toBTC()', function () {
+	describe('.fromBTC()', function () {
+		nock('https://blockchain.info')
+			.get('/frombtc')
+			.query(true)
+			.reply(200, '227.13');
 
+		it('should convert the currency', function (done) {
+			exchange.fromBTC(100000000, 1441308160481, 'USD')
+				.then(function (response) {
+					expect(response).to.equal('227.13');
+					done();
+				})
+				.catch(done);
+		});
+	});
+
+  describe('.toBTC()', function () {
     nock('https://blockchain.info')
-      .get('/tobtc').query(true)
+      .get('/tobtc')
+			.query(true)
       .reply(200, '1,234.1234');
 
     it('should convert the currency', function (done) {
@@ -52,7 +70,5 @@ describe('exchange', function () {
         })
         .catch(done);
     });
-
   });
-
 });


### PR DESCRIPTION
This PR satisfies issue #15 at a basic level. 

**Changes**
- Expose '/frombtc' endpoint with the exchange modules.
- Exchange module README.md updated with documentation for new method
- Added a basic unit test
- Updated the .gitignore with a few common excludes that were missing