### PR TITLE
Adding method to fetch mining pool statistics

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/exchange/README.md
+++ b/exchange/README.md
@@ -34,7 +34,7 @@ Usage:
 exchange.fromBTC(amount, currency, options);
 ```
 
-Gets the historical market price of the requested BTC amount at the requested time. Responds with the value in *string* format.
+Gets the historical market price of the requested BTC amount at the requested time. Responds with the value in *number* format.
 
 Required Parameters:
 

--- a/exchange/index.js
+++ b/exchange/index.js
@@ -5,7 +5,7 @@ var API         = require('../api')
 
 var endpoints  = {
   ticker  : new UrlPattern('/ticker(?api_code=:apiCode)'),
-	frombtc : new UrlPattern('/frombtc?value=:value&time=:time&currency=:currency(&api_code=:apiCode)'),
+  frombtc : new UrlPattern('/frombtc?value=:value&time=:time&currency=:currency(&api_code=:apiCode)'),
   tobtc   : new UrlPattern('/tobtc?value=:value&currency=:currency(&api_code=:apiCode)')
 };
 
@@ -13,7 +13,7 @@ var api = new API('https://blockchain.info', endpoints);
 
 module.exports = {
   getTicker : getTicker,
-	fromBTC   : fromBTC,
+  fromBTC   : fromBTC,
   toBTC     : toBTC
 };
 
@@ -24,9 +24,9 @@ function getTicker(options) {
 }
 
 function fromBTC(amount, currency, options) {
-	options = options || {};
-	return api.request('frombtc', { value: amount, time: options.time || 0, currency: currency, apiCode: options.apiCode })
-		.then(function (value) { return parseFloat(value) });
+  options = options || {};
+  return api.request('frombtc', { value: amount, time: options.time || 0, currency: currency, apiCode: options.apiCode })
+    .then(function (value) { return parseFloat(value) });
 }
 
 function toBTC(amount, currency, options) {

--- a/exchange/spec.js
+++ b/exchange/spec.js
@@ -8,13 +8,13 @@ describe('exchange', function () {
 
   describe('.getTicker()', function () {
     var ticker =  {
-    	USD: {
-    		'15m'   : 432.52,
-				last    : 432.52,
-				buy     : 432.52,
-				sell    : 433,
-				symbol  : '$'
-    	}
+      USD: {
+        '15m'  : 432.52,
+        last   : 432.52,
+        buy    : 432.52,
+        sell   : 433,
+        symbol : '$'
+      }
     };
 
     nock('https://blockchain.info')
@@ -40,26 +40,26 @@ describe('exchange', function () {
     });
   });
 
-	describe('.fromBTC()', function () {
-		nock('https://blockchain.info')
-			.get('/frombtc')
-			.query(true)
-			.reply(200, '227.13');
+  describe('.fromBTC()', function () {
+    nock('https://blockchain.info')
+      .get('/frombtc')
+      .query(true)
+      .reply(200, '227.13');
 
-		it('should convert the currency', function (done) {
-			exchange.fromBTC(100000000, 'USD')
-				.then(function (response) {
-					expect(response).to.equal(227.13);
-					done();
-				})
-				.catch(done);
-		});
-	});
+    it('should convert the currency', function (done) {
+      exchange.fromBTC(100000000, 'USD')
+        .then(function (response) {
+          expect(response).to.equal(227.13);
+          done();
+        })
+        .catch(done);
+    });
+  });
 
   describe('.toBTC()', function () {
     nock('https://blockchain.info')
       .get('/tobtc')
-			.query(true)
+      .query(true)
       .reply(200, '1,234.1234');
 
     it('should convert the currency', function (done) {

--- a/statistics/README.md
+++ b/statistics/README.md
@@ -20,7 +20,8 @@ Usage:
 statistics.get(options);
 ```
 
-Responds with a json *object* containing an overview of many Bitcoin statistics (view an example response [here][stats]), unless the `stat` option is specified.
+Responds with a json *object* containing an overview of many Bitcoin statistics unless the `stat` option is specified. 
+View an example response [here](https://api.blockchain.info/stats).
 
 Options (optional):
 
@@ -43,5 +44,21 @@ Parameters:
 Options:
 
   * `timespan` - interval for which to fetch data, can be set to `'all'` or a period of time formatted as `'<time><unit>'`, ex: `'2years'` or `'90d'` (*string*)
+
+### getPoolData
+
+Usage:
+
+```js
+statistics.getPoolData(options);
+```
+
+Responds with a json *object* containing mining pools and their total blocks mined in the last 4 days.
+View an example response [here](https://api.blockchain.info/pools?&timespan=4days).
+
+Options (optional):
+
+  * `timespan` - duration over which the data is computed (maximum 10 days), ex: `8` (*number*)
+
 
 [stats]: https://blockchain.info/api/charts_api

--- a/statistics/index.js
+++ b/statistics/index.js
@@ -4,16 +4,17 @@ var API         = require('../api')
   , q           = require('q')
   , UrlPattern  = require('url-pattern');
 
-var  endpoints  = {
-  charts  : new UrlPattern('/charts/:type?format=json(&api_code=:apiCode)(&timespan=:timespan)'),
-  stats   : new UrlPattern('/stats?format=json(&api_code=:apiCode)')
+var endpoints  = {
+  charts : new UrlPattern('/charts/:type?format=json(&api_code=:apiCode)(&timespan=:timespan)'),
+  stats  : new UrlPattern('/stats?format=json(&api_code=:apiCode)')
 };
 
 var api = new API('https://blockchain.info', endpoints);
 
 module.exports = {
-  get           : get,
-  getChartData  : getChartData
+  get          : get,
+  getChartData : getChartData,
+  getPoolData  : getPoolData
 };
 
 function get(options) {
@@ -32,5 +33,16 @@ function getChartData(chartType, options) {
     .request('charts', { type: chartType, apiCode: options.apiCode, timespan: options.timespan })
     .then(function (data) {
       return data.values || q.reject('Invalid chart type');
+    });
+}
+
+function getPoolData(options) {
+  var api = new API('https://api.blockchain.info', { pools : new UrlPattern('/pools?(timespan=:timespan)(:days)(&api_code=:apiCode)') });
+
+  options = options || {};
+  return api
+    .request('pools', { apiCode: options.apiCode, timespan: options.timespan, days: options.timespan ? 'days' : '' })
+    .then(function (data) {
+      return data || q.reject('Invalid timespan');
     });
 }

--- a/statistics/index.js
+++ b/statistics/index.js
@@ -6,6 +6,7 @@ var API         = require('../api')
 
 var endpoints  = {
   charts : new UrlPattern('/charts/:type?format=json(&api_code=:apiCode)(&timespan=:timespan)'),
+  pools  : new UrlPattern('/pools?format=json(&timespan=:timespan\\days)(&api_code=:apiCode)'),
   stats  : new UrlPattern('/stats?format=json(&api_code=:apiCode)')
 };
 
@@ -37,12 +38,10 @@ function getChartData(chartType, options) {
 }
 
 function getPoolData(options) {
-  var api = new API('https://api.blockchain.info', { pools : new UrlPattern('/pools?(timespan=:timespan)(:days)(&api_code=:apiCode)') });
-
   options = options || {};
   return api
     .request('pools', { apiCode: options.apiCode, timespan: options.timespan, days: options.timespan ? 'days' : '' })
     .then(function (data) {
-      return data || q.reject('Invalid timespan');
+      return data;
     });
 }

--- a/statistics/spec.js
+++ b/statistics/spec.js
@@ -38,12 +38,13 @@ describe('statistics', function () {
           done();
         });
     });
-
   });
 
   describe('.getChartData()', function () {
-    var chartData = [ { x: 100, y: 4 }
-                    , { x: 101, y: 8 } ];
+    var chartData = [
+      { x: 100, y: 4 },
+      { x: 101, y: 8 }
+    ];
 
     nock('https://blockchain.info')
       .get('/charts/market-cap').query(true)
@@ -57,7 +58,41 @@ describe('statistics', function () {
         })
         .catch(done);
     });
-
   });
 
+  describe('.getPoolData()', function () {
+
+    var poolData = {
+      "BitFury": 58,
+      "AntPool": 87
+    };
+
+    it('should get pool data', function (done) {
+
+      nock('https://api.blockchain.info')
+        .get('/pools?')
+        .reply(200, poolData);
+
+      statistics.getPoolData()
+        .then(function (data) {
+          expect(data).to.deep.equal(poolData);
+          done();
+        })
+        .catch(done);
+    });
+
+    it('should get pool data with optional timespan', function (done) {
+
+      nock('https://api.blockchain.info')
+        .get('/pools?timespan=8days')
+        .reply(200, poolData);
+
+      statistics.getPoolData({ timespan: 8 })
+        .then(function (data) {
+          expect(data).to.deep.equal(poolData);
+          done();
+        })
+        .catch(done);
+    });
+  });
 });

--- a/statistics/spec.js
+++ b/statistics/spec.js
@@ -69,8 +69,8 @@ describe('statistics', function () {
 
     it('should get pool data', function (done) {
 
-      nock('https://api.blockchain.info')
-        .get('/pools?')
+      nock('https://blockchain.info')
+        .get('/pools?format=json')
         .reply(200, poolData);
 
       statistics.getPoolData()
@@ -83,8 +83,8 @@ describe('statistics', function () {
 
     it('should get pool data with optional timespan', function (done) {
 
-      nock('https://api.blockchain.info')
-        .get('/pools?timespan=8days')
+      nock('https://blockchain.info')
+        .get('/pools?format=json&timespan=8days')
         .reply(200, poolData);
 
       statistics.getPoolData({ timespan: 8 })


### PR DESCRIPTION
This PR addresses issue #23.

Quirks:
In the `getPoolData` method, I had to create a new API Object to point to `https://api.blockchain.info` instead of the default `https://blockchain.info` base url.  If you hit the "normal" base url, you will receive the HTML for this [page](https://blockchain.info/pools).  Please let me if there is a different way to do this.... ¯\\__(ツ)_/¯

Other changes:
- Unit tests for new method
- Added a .editorconfig file to fix spacing/indenting issues between IDE's
- fixed spacing/indenting issues from my last PR
- fixed typo in `exchange/readme.md`
