### PR TITLE
remove satoshi input

### DIFF
--- a/exchange/README.md
+++ b/exchange/README.md
@@ -57,5 +57,5 @@ Converts an amount of a given currency to BTC. Responds with a number in *string
 
 Parameters:
 
-  * `amount` - the amount to convert (satoshi, *number*)
+  * `amount` - the amount to convert (*number*)
   * `currency` - the code of the currency to convert from (currency code, *string*)

--- a/exchange/index.js
+++ b/exchange/index.js
@@ -29,6 +29,6 @@ function fromBTC (amount, currency, options) {
 
 function toBTC (amount, currency, options) {
   options = options || {}
-  return api.request('tobtc', { value: amount / 100000000, currency: currency, apiCode: options.apiCode })
+  return api.request('tobtc', { value: amount, currency: currency, apiCode: options.apiCode })
     .then(function (rvalue) { return parseFloat(rvalue.toString().replace(',', '')) })
 }


### PR DESCRIPTION
It's confusing and unnecessary to have the parameter for toBTC in satoshi, when you want a normal currency.