### PR TITLE
Update README.md to correct documentation.

### DIFF
--- a/MyWallet/README.md
+++ b/MyWallet/README.md
@@ -110,10 +110,10 @@ Parameters:
 
   * `address` - bitcoin address to send to
   * `amount` - amount **in satoshi** to send
-  * `from` - send from a specific Bitcoin address or account index (*string*|*number*, required when sending from an account)
-
+  
 Options (optional):
 
+  * `from` - send from a specific Bitcoin address or account index (*string*|*number*, required when sending from an account)
   * `fee` - transaction fee value **in satoshi** (*number*, defaults to 0.0001btc)
   * `feePerByte` - transaction fee **in satoshi per byte** (*number*, recommended)
 
@@ -130,10 +130,10 @@ Sends bitcoin to multiple addresses. Responds with a Payment Response Object.
 Parameters:
 
   * `recipients` - *object* with properties/values in the format: "receivingAddress":amount (required)
-  * `from` - send from a specific Bitcoin address or account index (*string*|*number*, required when sending from an account)
-
+  
 Options (optional):
 
+  * `from` - send from a specific Bitcoin address or account index (*string*|*number*, required when sending from an account)
   * `fee` - transaction fee value **in satoshi** (*number*, defaults to 0.0001btc)
   * `feePerByte` - transaction fee **in satoshi per byte** (*number*, recommended)
 


### PR DESCRIPTION
The documentation for send and sendMany is wrong.  It lists `from` as a parameter.   `from` is actually an option.